### PR TITLE
corrected velocity dispersion calculation

### DIFF
--- a/qsoabsfind/absfinder.py
+++ b/qsoabsfind/absfinder.py
@@ -169,9 +169,11 @@ mult_resi=1, d_pix=0.6, pm_pixel=200, sn_line1=3, sn_line2=2, use_covariance=Fal
         if not logwave:
             # average resolution in case wavelength is on linear scale
             wave_pixel = np.nanmean(lam_search[1:] - lam_search[:-1])
-            del_sigma = wave_pixel / 2.355
-            resolution  = np.nanmean(wave_pixel/lam_obs) * speed_of_light
+            del_sigma = wave_pixel / 2.355 # this is just to define the boundary for gaussian fits
+            resolution  = wave_pixel/lam_obs * speed_of_light # an array
         else:
+            if resolution is None:
+                raise ValueError(f"ERROR: must provide instrumental resolution of the spectrum in km/s")
             del_sigma = line1 * resolution / speed_of_light  # in Ang
             del_sigma = del_sigma / 2.355 ## FWHM sqrt(8ln2)
 
@@ -249,11 +251,11 @@ mult_resi=1, d_pix=0.6, pm_pixel=200, sn_line1=3, sn_line2=2, use_covariance=Fal
                         sig1, sig2  = gaussian_parameters[2], gaussian_parameters[5]
                         #S/N estimation
                         sn1, sn2 = estimate_snr_for_lines(c0, c1, sig1, sig2, lam_rest, residual, error, logwave)
-                        # resolution corrected velocity dispersion (should be greater than 0)
-                        vel1, vel2 = vel_dispersion(c0, c1, gaussian_parameters[2], gaussian_parameters[5], resolution)
+                        # resolution corrected velocity dispersion (should be greater than 0) 
+                        vel1, vel2 = vel_dispersion(c0, c1, gaussian_parameters[2], gaussian_parameters[5], resolution, z_abs[m], lam_obs)
                         # calculate best -fit doublet ratio and errors and check if they are within the range.
+                        # usually 1 < DR < f1/f2 (doublet ratio =2, for MgII, CIV), also applying SNR for EW >1, these are strict cuts
 
-                        # usually 1 < DR < f1/f2 (doublet ratio =2, for MgII, CIV)
                         if EW_first_temp_mean[0] > 0 and EW_second_temp_mean[0] > 0:
                             dr, dr_error = calculate_doublet_ratio(EW_first_temp_mean[0], EW_second_temp_mean[0], EW_first_error_temp[0], EW_second_error_temp[0])
                             min_dr, max_dr = 1 -  dr_error, f1/f2 +  dr_error

--- a/qsoabsfind/utils.py
+++ b/qsoabsfind/utils.py
@@ -11,7 +11,7 @@ import os
 from astropy.io import fits
 from astropy.table import Table
 import re
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 
 # Configure logging
 #logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -22,6 +22,7 @@ import pkg_resources
 constants = load_constants()
 lines, amplitude_dict, speed_of_light = constants.lines, constants.amplitude_dict, constants.speed_of_light
 
+
 def get_package_versions():
     """
     Get the versions of qsoabsfind and other relevant packages.
@@ -30,8 +31,14 @@ def get_package_versions():
         dict: A dictionary containing the versions of the packages.
     """
     packages = ['qsoabsfind', 'numpy', 'astropy', 'scipy', 'numba', 'matplotlib']
-    versions = {pkg: pkg_resources.get_distribution(pkg).version for pkg in packages}
+    versions = {}
+    for pkg in packages:
+        try:
+            versions[pkg] = version(pkg)
+        except PackageNotFoundError:
+            versions[pkg] = 'not installed'
     return versions
+
 
 def parse_qso_sequence(qso_sequence):
     """
@@ -336,36 +343,46 @@ def validate_sizes(conv_arr, unmsk_residual, spec_index):
         # raise
     return bad_conv
 
-def vel_dispersion(c1, c2, sigma1, sigma2, resolution):
+def vel_dispersion(c1, c2, sigma1, sigma2, resolution, z, obs_wave):
     """
-    Calculates velocity dispersion using Gaussian quadrature.
+    Calculates and corrects velocity dispersion using Gaussian quadrature.
 
     Args:
-        c1 (float): fitted line center 1 (in Ang).
-        c2 (float): fitted line center 2 (in Ang).
-        sigma1 (float): fitted width 1 (in Ang).
-        sigma2 (float): fitted width 2 (in Ang).
-        resoultion (float): instrumental resolution (in km/s).
+        c1 (float): rest-frame fitted line center 1 (in Ang).
+        c2 (float): rest-frame fitted line center 2 (in Ang).
+        sigma1 (float): rest-frame fitted width 1 (in Ang).
+        sigma2 (float): rest-frame fitted width 2 (in Ang).
+        resolution (float or np.array): instrumental resolution (in km/s).
+        z (float): redshift of absorber
+        obs_wave (np.array): observed wavelength in Angstroms
 
     Returns:
-        resolution corrected velocity dispersion
+        instrumental resolution corrected velocity dispersion in km/s
     """
 
     v1_sig = sigma1 / c1 * speed_of_light
     v2_sig = sigma2 / c2 * speed_of_light
 
-    # FWHM of instrument
-    resolution = resolution/2.355
+    lam_obs1 = (1 + z) * c1
+    lam_obs2 = (1 + z) * c2
 
-    del_v1_sq = v1_sig**2 - resolution**2
-    del_v2_sq = v2_sig**2 - resolution**2
+    # Get per-line resolution (scalar or from array)
+    res1 = resolution if np.isscalar(resolution) else resolution[np.argmin(np.abs(obs_wave - lam_obs1))]
+    res2 = resolution if np.isscalar(resolution) else resolution[np.argmin(np.abs(obs_wave - lam_obs2))]
+
+    # Convert to rest-frame
+    res1_rest = res1 / (1 + z)
+    res2_rest = res2 / (1 + z)
+
+    del_v1_sq = v1_sig**2 - res1_rest**2
+    del_v2_sq = v2_sig**2 - res1_rest**2
 
     # Correct for instrumental resolution
     if del_v1_sq > 0 and del_v2_sq > 0:
         corr_del_v1_sq = np.sqrt(del_v1_sq)
         corr_del_v2_sq = np.sqrt(del_v2_sq)
     else:
-        corr_del_v1_sq  = 0.0  # Set to 0 if the observed width is less than instrumental width
+        corr_del_v1_sq  = 0.0  # Set to 0 if the fitted width is less than rest-frame instrumental width for any one line
         corr_del_v2_sq  = 0.0
 
     return corr_del_v1_sq, corr_del_v2_sq


### PR DESCRIPTION
### PR: Add Rest-Frame Velocity Dispersion Correction (`vel_disp` branch)

This PR improves the calculation of absorber velocity dispersion by properly correcting for instrumental resolution in the **rest-frame** of each absorber. It also resolves the bug in code with `versions <= 1.0.4.` In the original version, while estimating velocity dispersions, we divided the observed instrumental resolution by a constant factor of 2.355, which underestimated the line dispersion by a few km/s. Overall, the difference is not significant.

#### Key Changes:

- Corrected velocity dispersion formula using rest-frame instrumental resolution:

  `sigma_instr_rest = sigma_instr_obs / (1 + z)`

- Updated `vel_dispersion()` to handle both scalar and array-based resolution inputs
- Integrated logic to look up resolution at absorber wavelength from the observed wavelength grid
- Compute`CIV_1548_VDISP` and `CIV_1550_VDISP` using corrected rest-frame logic
- Also added new implementation for reading version of used modules

#### Validation:

- Validated against `main`: updated velocity dispersions are systematically higher by a few km/s, as expected from rest-frame instrumental resolution correction.

These updates ensure more accurate intrinsic line width estimates and better alignment with the instrumental profile and absorber rest-frame analysis.
